### PR TITLE
- Design the Settings Screen and Toggle between two themes using cubit. ✅☕

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.preparation.interviewhatak.interviewhatak">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+
 
 <application
         android:name="${applicationName}"

--- a/lib/core/di/dependency_injection.dart
+++ b/lib/core/di/dependency_injection.dart
@@ -1,6 +1,8 @@
 import 'package:get_it/get_it.dart';
 import 'package:interviewhatak/core/networking/categories/category_service.dart';
 import 'package:interviewhatak/core/networking/categories/category_service_imp.dart';
+import 'package:interviewhatak/core/networking/contact/contact_service.dart';
+import 'package:interviewhatak/core/networking/contact/contact_service_impl.dart';
 import 'package:interviewhatak/core/networking/favorite/favorite_service.dart';
 import 'package:interviewhatak/core/networking/favorite/favorite_service_impl.dart';
 import 'package:interviewhatak/core/networking/fields/fields_service.dart';
@@ -11,6 +13,10 @@ import 'package:interviewhatak/core/networking/register/register_service.dart';
 import 'package:interviewhatak/core/networking/register/register_service_impl.dart';
 import 'package:interviewhatak/core/networking/sections/section_service.dart';
 import 'package:interviewhatak/core/networking/sections/section_service_impl.dart';
+import 'package:interviewhatak/core/networking/users/user_service.dart';
+import 'package:interviewhatak/core/networking/users/user_service_impl.dart';
+import 'package:interviewhatak/interviewhatak/contact_us/controller/cubit/contact_cubit.dart';
+import 'package:interviewhatak/interviewhatak/contact_us/data/repository/contact_repository.dart';
 import 'package:interviewhatak/interviewhatak/dashboard/controller/dashboard_cubit.dart';
 import 'package:interviewhatak/interviewhatak/category/controller/category_cubit.dart';
 import 'package:interviewhatak/interviewhatak/category/data/repository/category_repo.dart';
@@ -20,6 +26,8 @@ import 'package:interviewhatak/interviewhatak/field/controller/field_cubit.dart'
 import 'package:interviewhatak/interviewhatak/field/data/repository/fields_repository.dart';
 import 'package:interviewhatak/interviewhatak/login/controller/login_cubit.dart';
 import 'package:interviewhatak/interviewhatak/login/data/repository/login_repository.dart';
+import 'package:interviewhatak/interviewhatak/profile/controller/user_cubit.dart';
+import 'package:interviewhatak/interviewhatak/profile/data/repository/user_repository.dart';
 import 'package:interviewhatak/interviewhatak/question/controller/cubit/question_cubit.dart';
 import 'package:interviewhatak/interviewhatak/question/data/repository/question_repository.dart';
 import 'package:interviewhatak/interviewhatak/section/controller/cubit/section_cubit.dart';
@@ -74,4 +82,15 @@ Future<void> setupGetIt() async {
   getIt.registerLazySingleton<FavoriteRepository>(
       () => FavoriteRepository(getIt()));
   getIt.registerFactory<FavoriteCubit>(() => FavoriteCubit(getIt()));
+
+  ///Profile
+  getIt.registerLazySingleton<UserService>(() => UserServiceImpl());
+  getIt.registerLazySingleton<UserRepository>(() => UserRepository(getIt()));
+  getIt.registerFactory<UserCubit>(() => UserCubit(getIt()));
+
+  ///Contact
+  getIt.registerLazySingleton<ContactService>(() => ContactServiceImpl());
+  getIt.registerLazySingleton<ContactRepository>(
+      () => ContactRepository(getIt()));
+  getIt.registerFactory<ContactCubit>(() => ContactCubit(getIt()));
 }

--- a/lib/core/helpers/constants.dart
+++ b/lib/core/helpers/constants.dart
@@ -1,4 +1,8 @@
 class Constants {
   static String? categoryName;
   static String? fieldName;
+
+  static String? userKey;
+
+  static bool isDark = false;
 }

--- a/lib/core/helpers/separator.dart
+++ b/lib/core/helpers/separator.dart
@@ -1,14 +1,15 @@
 import 'package:flutter/cupertino.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:interviewhatak/core/theming/app_colors/app_colors.dart';
 
 Widget heightSeparator() => Container(
-      width: double.infinity,
-      height: 1,
-      color: AppColors.grey,
+      width: 250.w,
+      height: .6,
+      color: AppColors.white.withValues(alpha: .2),
     );
 
 Widget widthSeparator() => Container(
-  width: 1,
-  height: double.infinity,
-  color: AppColors.grey,
-);
+      width: 1,
+      height: double.infinity,
+      color: AppColors.grey,
+    );

--- a/lib/core/networking/register/register_service.dart
+++ b/lib/core/networking/register/register_service.dart
@@ -9,6 +9,4 @@ abstract class RegisterService {
       RegisterRequestModel registerRequestModel);
 
   Future<ServerResult<String?>> login(LoginRequestModel loginRequestModel);
-
-  Future<void> signOut();
 }

--- a/lib/core/networking/register/register_service_impl.dart
+++ b/lib/core/networking/register/register_service_impl.dart
@@ -38,10 +38,4 @@ class RegisterServiceImpl implements RegisterService {
       return ServerResult.failure(error.toString());
     }
   }
-
-  @override
-  Future<void> signOut() {
-    // TODO: implement signOut
-    throw UnimplementedError();
-  }
 }

--- a/lib/core/networking/users/user_service.dart
+++ b/lib/core/networking/users/user_service.dart
@@ -1,0 +1,10 @@
+import 'package:interviewhatak/core/networking/server_result.dart';
+import 'package:interviewhatak/interviewhatak/profile/data/model/user_model.dart';
+
+abstract class UserService {
+  Future<ServerResult<UserModel>> getUser();
+
+  Future<ServerResult<void>> updateUser(UserModel userModel);
+
+  Future<void> signOut();
+}

--- a/lib/core/networking/users/user_service_impl.dart
+++ b/lib/core/networking/users/user_service_impl.dart
@@ -1,0 +1,57 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:interviewhatak/core/networking/server_result.dart';
+import 'package:interviewhatak/core/networking/users/user_service.dart';
+import 'package:interviewhatak/interviewhatak/profile/data/model/user_model.dart';
+
+class UserServiceImpl implements UserService {
+  final FirebaseFirestore _firebaseFirestore = FirebaseFirestore.instance;
+  final User? user = FirebaseAuth.instance.currentUser;
+  @override
+  Future<ServerResult<UserModel>> getUser() async {
+    try {
+      if (user != null) {
+        final userId = user?.uid;
+        final docSnapshot =
+            await _firebaseFirestore.collection('users').doc(userId).get();
+        if (docSnapshot.exists) {
+          final data = docSnapshot.data()!;
+          final user = UserModel(
+              name: data['name'],
+              email: data['email'],
+              phone: data['phone'],
+              image: data['image']);
+          return ServerResult.success(user);
+        }
+      }
+    } catch (error) {
+      return ServerResult.failure(error.toString());
+    }
+    return ServerResult.failure("error happend");
+  }
+
+  @override
+  Future<ServerResult<void>> updateUser(UserModel userModel) async {
+    try {
+      if (user != null) {
+        final userId = user?.uid;
+        final userRef = _firebaseFirestore.collection('users').doc(userId);
+        final response = await userRef.update({
+          'name': userModel.name,
+          'email': userModel.email,
+          'phone': userModel.phone,
+          'image': userModel.image,
+        });
+        return ServerResult.success(response);
+      }
+    } catch (error) {
+      return ServerResult.failure(error.toString());
+    }
+    return ServerResult.failure('Error Happed');
+  }
+
+  @override
+  Future<void> signOut() async {
+    await FirebaseAuth.instance.signOut();
+  }
+}

--- a/lib/core/widgets/alert_dialog.dart
+++ b/lib/core/widgets/alert_dialog.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/cupertino.dart';
 import 'package:interviewhatak/core/theming/app_strings/app_string.dart';
 
-class AlertDialog extends StatelessWidget {
-  const AlertDialog({super.key});
+class AlertDialogWidget extends StatelessWidget {
+  const AlertDialogWidget({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/interviewhatak/profile/controller/user_cubit.dart
+++ b/lib/interviewhatak/profile/controller/user_cubit.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:interviewhatak/interviewhatak/profile/controller/user_state.dart';
+import 'package:interviewhatak/interviewhatak/profile/data/model/user_model.dart';
+import 'package:interviewhatak/interviewhatak/profile/data/repository/user_repository.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class UserCubit extends Cubit<UserState> {
+  final UserRepository userRepository;
+  UserCubit(this.userRepository) : super(UserState.initial());
+
+  TextEditingController nameController = TextEditingController();
+  TextEditingController emailController = TextEditingController();
+  TextEditingController phoneController = TextEditingController();
+  final editProfileFormKey = GlobalKey<FormState>();
+
+  Future<void> getUser() async {
+    emit(UserState.loading());
+    final result = await userRepository.getUser();
+    result.when(
+      success: (data) {
+        emit(UserState.loaded(data));
+      },
+      failure: (error) => emit(UserState.error(error)),
+    );
+  }
+
+  Future<void> updateUser(UserModel user) async {
+    emit(UserState.loading());
+    final result = await userRepository.updateUser(user);
+    result.when(
+      success: (data) => emit(UserState.loaded(user)),
+      failure: (error) => emit(UserState.error(error)),
+    );
+  }
+
+  Future<void> signOut() async {
+    try {
+      await userRepository.signOut();
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.clear();
+      final user = UserModel(name: '', email: '', phone: '');
+      emit(UserState.out(user));
+    } catch (error) {
+      print('the error when logout is ${error.toString()}');
+      emit(UserState.error(error.toString()));
+    }
+  }
+}

--- a/lib/interviewhatak/profile/controller/user_state.dart
+++ b/lib/interviewhatak/profile/controller/user_state.dart
@@ -1,0 +1,12 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:interviewhatak/interviewhatak/profile/data/model/user_model.dart';
+part 'user_state.freezed.dart';
+
+@freezed
+class UserState<T> with _$UserState<T> {
+  const factory UserState.initial() = _Initial;
+  const factory UserState.loading() = Loading;
+  const factory UserState.loaded(UserModel users) = Loaded;
+  const factory UserState.out(UserModel users) = Out;
+  const factory UserState.error(String message) = Error;
+}

--- a/lib/interviewhatak/profile/controller/user_state.freezed.dart
+++ b/lib/interviewhatak/profile/controller/user_state.freezed.dart
@@ -1,0 +1,816 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'user_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$UserState<T> {
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function() loading,
+    required TResult Function(UserModel users) loaded,
+    required TResult Function(UserModel users) out,
+    required TResult Function(String message) error,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initial,
+    TResult? Function()? loading,
+    TResult? Function(UserModel users)? loaded,
+    TResult? Function(UserModel users)? out,
+    TResult? Function(String message)? error,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? loading,
+    TResult Function(UserModel users)? loaded,
+    TResult Function(UserModel users)? out,
+    TResult Function(String message)? error,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initial<T> value) initial,
+    required TResult Function(Loading<T> value) loading,
+    required TResult Function(Loaded<T> value) loaded,
+    required TResult Function(Out<T> value) out,
+    required TResult Function(Error<T> value) error,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initial<T> value)? initial,
+    TResult? Function(Loading<T> value)? loading,
+    TResult? Function(Loaded<T> value)? loaded,
+    TResult? Function(Out<T> value)? out,
+    TResult? Function(Error<T> value)? error,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initial<T> value)? initial,
+    TResult Function(Loading<T> value)? loading,
+    TResult Function(Loaded<T> value)? loaded,
+    TResult Function(Out<T> value)? out,
+    TResult Function(Error<T> value)? error,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $UserStateCopyWith<T, $Res> {
+  factory $UserStateCopyWith(
+          UserState<T> value, $Res Function(UserState<T>) then) =
+      _$UserStateCopyWithImpl<T, $Res, UserState<T>>;
+}
+
+/// @nodoc
+class _$UserStateCopyWithImpl<T, $Res, $Val extends UserState<T>>
+    implements $UserStateCopyWith<T, $Res> {
+  _$UserStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of UserState
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+abstract class _$$InitialImplCopyWith<T, $Res> {
+  factory _$$InitialImplCopyWith(
+          _$InitialImpl<T> value, $Res Function(_$InitialImpl<T>) then) =
+      __$$InitialImplCopyWithImpl<T, $Res>;
+}
+
+/// @nodoc
+class __$$InitialImplCopyWithImpl<T, $Res>
+    extends _$UserStateCopyWithImpl<T, $Res, _$InitialImpl<T>>
+    implements _$$InitialImplCopyWith<T, $Res> {
+  __$$InitialImplCopyWithImpl(
+      _$InitialImpl<T> _value, $Res Function(_$InitialImpl<T>) _then)
+      : super(_value, _then);
+
+  /// Create a copy of UserState
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+
+class _$InitialImpl<T> implements _Initial<T> {
+  const _$InitialImpl();
+
+  @override
+  String toString() {
+    return 'UserState<$T>.initial()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$InitialImpl<T>);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function() loading,
+    required TResult Function(UserModel users) loaded,
+    required TResult Function(UserModel users) out,
+    required TResult Function(String message) error,
+  }) {
+    return initial();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initial,
+    TResult? Function()? loading,
+    TResult? Function(UserModel users)? loaded,
+    TResult? Function(UserModel users)? out,
+    TResult? Function(String message)? error,
+  }) {
+    return initial?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? loading,
+    TResult Function(UserModel users)? loaded,
+    TResult Function(UserModel users)? out,
+    TResult Function(String message)? error,
+    required TResult orElse(),
+  }) {
+    if (initial != null) {
+      return initial();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initial<T> value) initial,
+    required TResult Function(Loading<T> value) loading,
+    required TResult Function(Loaded<T> value) loaded,
+    required TResult Function(Out<T> value) out,
+    required TResult Function(Error<T> value) error,
+  }) {
+    return initial(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initial<T> value)? initial,
+    TResult? Function(Loading<T> value)? loading,
+    TResult? Function(Loaded<T> value)? loaded,
+    TResult? Function(Out<T> value)? out,
+    TResult? Function(Error<T> value)? error,
+  }) {
+    return initial?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initial<T> value)? initial,
+    TResult Function(Loading<T> value)? loading,
+    TResult Function(Loaded<T> value)? loaded,
+    TResult Function(Out<T> value)? out,
+    TResult Function(Error<T> value)? error,
+    required TResult orElse(),
+  }) {
+    if (initial != null) {
+      return initial(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _Initial<T> implements UserState<T> {
+  const factory _Initial() = _$InitialImpl<T>;
+}
+
+/// @nodoc
+abstract class _$$LoadingImplCopyWith<T, $Res> {
+  factory _$$LoadingImplCopyWith(
+          _$LoadingImpl<T> value, $Res Function(_$LoadingImpl<T>) then) =
+      __$$LoadingImplCopyWithImpl<T, $Res>;
+}
+
+/// @nodoc
+class __$$LoadingImplCopyWithImpl<T, $Res>
+    extends _$UserStateCopyWithImpl<T, $Res, _$LoadingImpl<T>>
+    implements _$$LoadingImplCopyWith<T, $Res> {
+  __$$LoadingImplCopyWithImpl(
+      _$LoadingImpl<T> _value, $Res Function(_$LoadingImpl<T>) _then)
+      : super(_value, _then);
+
+  /// Create a copy of UserState
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+
+class _$LoadingImpl<T> implements Loading<T> {
+  const _$LoadingImpl();
+
+  @override
+  String toString() {
+    return 'UserState<$T>.loading()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$LoadingImpl<T>);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function() loading,
+    required TResult Function(UserModel users) loaded,
+    required TResult Function(UserModel users) out,
+    required TResult Function(String message) error,
+  }) {
+    return loading();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initial,
+    TResult? Function()? loading,
+    TResult? Function(UserModel users)? loaded,
+    TResult? Function(UserModel users)? out,
+    TResult? Function(String message)? error,
+  }) {
+    return loading?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? loading,
+    TResult Function(UserModel users)? loaded,
+    TResult Function(UserModel users)? out,
+    TResult Function(String message)? error,
+    required TResult orElse(),
+  }) {
+    if (loading != null) {
+      return loading();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initial<T> value) initial,
+    required TResult Function(Loading<T> value) loading,
+    required TResult Function(Loaded<T> value) loaded,
+    required TResult Function(Out<T> value) out,
+    required TResult Function(Error<T> value) error,
+  }) {
+    return loading(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initial<T> value)? initial,
+    TResult? Function(Loading<T> value)? loading,
+    TResult? Function(Loaded<T> value)? loaded,
+    TResult? Function(Out<T> value)? out,
+    TResult? Function(Error<T> value)? error,
+  }) {
+    return loading?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initial<T> value)? initial,
+    TResult Function(Loading<T> value)? loading,
+    TResult Function(Loaded<T> value)? loaded,
+    TResult Function(Out<T> value)? out,
+    TResult Function(Error<T> value)? error,
+    required TResult orElse(),
+  }) {
+    if (loading != null) {
+      return loading(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class Loading<T> implements UserState<T> {
+  const factory Loading() = _$LoadingImpl<T>;
+}
+
+/// @nodoc
+abstract class _$$LoadedImplCopyWith<T, $Res> {
+  factory _$$LoadedImplCopyWith(
+          _$LoadedImpl<T> value, $Res Function(_$LoadedImpl<T>) then) =
+      __$$LoadedImplCopyWithImpl<T, $Res>;
+  @useResult
+  $Res call({UserModel users});
+}
+
+/// @nodoc
+class __$$LoadedImplCopyWithImpl<T, $Res>
+    extends _$UserStateCopyWithImpl<T, $Res, _$LoadedImpl<T>>
+    implements _$$LoadedImplCopyWith<T, $Res> {
+  __$$LoadedImplCopyWithImpl(
+      _$LoadedImpl<T> _value, $Res Function(_$LoadedImpl<T>) _then)
+      : super(_value, _then);
+
+  /// Create a copy of UserState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? users = null,
+  }) {
+    return _then(_$LoadedImpl<T>(
+      null == users
+          ? _value.users
+          : users // ignore: cast_nullable_to_non_nullable
+              as UserModel,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$LoadedImpl<T> implements Loaded<T> {
+  const _$LoadedImpl(this.users);
+
+  @override
+  final UserModel users;
+
+  @override
+  String toString() {
+    return 'UserState<$T>.loaded(users: $users)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$LoadedImpl<T> &&
+            (identical(other.users, users) || other.users == users));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, users);
+
+  /// Create a copy of UserState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$LoadedImplCopyWith<T, _$LoadedImpl<T>> get copyWith =>
+      __$$LoadedImplCopyWithImpl<T, _$LoadedImpl<T>>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function() loading,
+    required TResult Function(UserModel users) loaded,
+    required TResult Function(UserModel users) out,
+    required TResult Function(String message) error,
+  }) {
+    return loaded(users);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initial,
+    TResult? Function()? loading,
+    TResult? Function(UserModel users)? loaded,
+    TResult? Function(UserModel users)? out,
+    TResult? Function(String message)? error,
+  }) {
+    return loaded?.call(users);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? loading,
+    TResult Function(UserModel users)? loaded,
+    TResult Function(UserModel users)? out,
+    TResult Function(String message)? error,
+    required TResult orElse(),
+  }) {
+    if (loaded != null) {
+      return loaded(users);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initial<T> value) initial,
+    required TResult Function(Loading<T> value) loading,
+    required TResult Function(Loaded<T> value) loaded,
+    required TResult Function(Out<T> value) out,
+    required TResult Function(Error<T> value) error,
+  }) {
+    return loaded(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initial<T> value)? initial,
+    TResult? Function(Loading<T> value)? loading,
+    TResult? Function(Loaded<T> value)? loaded,
+    TResult? Function(Out<T> value)? out,
+    TResult? Function(Error<T> value)? error,
+  }) {
+    return loaded?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initial<T> value)? initial,
+    TResult Function(Loading<T> value)? loading,
+    TResult Function(Loaded<T> value)? loaded,
+    TResult Function(Out<T> value)? out,
+    TResult Function(Error<T> value)? error,
+    required TResult orElse(),
+  }) {
+    if (loaded != null) {
+      return loaded(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class Loaded<T> implements UserState<T> {
+  const factory Loaded(final UserModel users) = _$LoadedImpl<T>;
+
+  UserModel get users;
+
+  /// Create a copy of UserState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$LoadedImplCopyWith<T, _$LoadedImpl<T>> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$OutImplCopyWith<T, $Res> {
+  factory _$$OutImplCopyWith(
+          _$OutImpl<T> value, $Res Function(_$OutImpl<T>) then) =
+      __$$OutImplCopyWithImpl<T, $Res>;
+  @useResult
+  $Res call({UserModel users});
+}
+
+/// @nodoc
+class __$$OutImplCopyWithImpl<T, $Res>
+    extends _$UserStateCopyWithImpl<T, $Res, _$OutImpl<T>>
+    implements _$$OutImplCopyWith<T, $Res> {
+  __$$OutImplCopyWithImpl(
+      _$OutImpl<T> _value, $Res Function(_$OutImpl<T>) _then)
+      : super(_value, _then);
+
+  /// Create a copy of UserState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? users = null,
+  }) {
+    return _then(_$OutImpl<T>(
+      null == users
+          ? _value.users
+          : users // ignore: cast_nullable_to_non_nullable
+              as UserModel,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$OutImpl<T> implements Out<T> {
+  const _$OutImpl(this.users);
+
+  @override
+  final UserModel users;
+
+  @override
+  String toString() {
+    return 'UserState<$T>.out(users: $users)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$OutImpl<T> &&
+            (identical(other.users, users) || other.users == users));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, users);
+
+  /// Create a copy of UserState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$OutImplCopyWith<T, _$OutImpl<T>> get copyWith =>
+      __$$OutImplCopyWithImpl<T, _$OutImpl<T>>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function() loading,
+    required TResult Function(UserModel users) loaded,
+    required TResult Function(UserModel users) out,
+    required TResult Function(String message) error,
+  }) {
+    return out(users);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initial,
+    TResult? Function()? loading,
+    TResult? Function(UserModel users)? loaded,
+    TResult? Function(UserModel users)? out,
+    TResult? Function(String message)? error,
+  }) {
+    return out?.call(users);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? loading,
+    TResult Function(UserModel users)? loaded,
+    TResult Function(UserModel users)? out,
+    TResult Function(String message)? error,
+    required TResult orElse(),
+  }) {
+    if (out != null) {
+      return out(users);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initial<T> value) initial,
+    required TResult Function(Loading<T> value) loading,
+    required TResult Function(Loaded<T> value) loaded,
+    required TResult Function(Out<T> value) out,
+    required TResult Function(Error<T> value) error,
+  }) {
+    return out(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initial<T> value)? initial,
+    TResult? Function(Loading<T> value)? loading,
+    TResult? Function(Loaded<T> value)? loaded,
+    TResult? Function(Out<T> value)? out,
+    TResult? Function(Error<T> value)? error,
+  }) {
+    return out?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initial<T> value)? initial,
+    TResult Function(Loading<T> value)? loading,
+    TResult Function(Loaded<T> value)? loaded,
+    TResult Function(Out<T> value)? out,
+    TResult Function(Error<T> value)? error,
+    required TResult orElse(),
+  }) {
+    if (out != null) {
+      return out(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class Out<T> implements UserState<T> {
+  const factory Out(final UserModel users) = _$OutImpl<T>;
+
+  UserModel get users;
+
+  /// Create a copy of UserState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$OutImplCopyWith<T, _$OutImpl<T>> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$ErrorImplCopyWith<T, $Res> {
+  factory _$$ErrorImplCopyWith(
+          _$ErrorImpl<T> value, $Res Function(_$ErrorImpl<T>) then) =
+      __$$ErrorImplCopyWithImpl<T, $Res>;
+  @useResult
+  $Res call({String message});
+}
+
+/// @nodoc
+class __$$ErrorImplCopyWithImpl<T, $Res>
+    extends _$UserStateCopyWithImpl<T, $Res, _$ErrorImpl<T>>
+    implements _$$ErrorImplCopyWith<T, $Res> {
+  __$$ErrorImplCopyWithImpl(
+      _$ErrorImpl<T> _value, $Res Function(_$ErrorImpl<T>) _then)
+      : super(_value, _then);
+
+  /// Create a copy of UserState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? message = null,
+  }) {
+    return _then(_$ErrorImpl<T>(
+      null == message
+          ? _value.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$ErrorImpl<T> implements Error<T> {
+  const _$ErrorImpl(this.message);
+
+  @override
+  final String message;
+
+  @override
+  String toString() {
+    return 'UserState<$T>.error(message: $message)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ErrorImpl<T> &&
+            (identical(other.message, message) || other.message == message));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, message);
+
+  /// Create a copy of UserState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ErrorImplCopyWith<T, _$ErrorImpl<T>> get copyWith =>
+      __$$ErrorImplCopyWithImpl<T, _$ErrorImpl<T>>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function() loading,
+    required TResult Function(UserModel users) loaded,
+    required TResult Function(UserModel users) out,
+    required TResult Function(String message) error,
+  }) {
+    return error(message);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initial,
+    TResult? Function()? loading,
+    TResult? Function(UserModel users)? loaded,
+    TResult? Function(UserModel users)? out,
+    TResult? Function(String message)? error,
+  }) {
+    return error?.call(message);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? loading,
+    TResult Function(UserModel users)? loaded,
+    TResult Function(UserModel users)? out,
+    TResult Function(String message)? error,
+    required TResult orElse(),
+  }) {
+    if (error != null) {
+      return error(message);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initial<T> value) initial,
+    required TResult Function(Loading<T> value) loading,
+    required TResult Function(Loaded<T> value) loaded,
+    required TResult Function(Out<T> value) out,
+    required TResult Function(Error<T> value) error,
+  }) {
+    return error(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initial<T> value)? initial,
+    TResult? Function(Loading<T> value)? loading,
+    TResult? Function(Loaded<T> value)? loaded,
+    TResult? Function(Out<T> value)? out,
+    TResult? Function(Error<T> value)? error,
+  }) {
+    return error?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initial<T> value)? initial,
+    TResult Function(Loading<T> value)? loading,
+    TResult Function(Loaded<T> value)? loaded,
+    TResult Function(Out<T> value)? out,
+    TResult Function(Error<T> value)? error,
+    required TResult orElse(),
+  }) {
+    if (error != null) {
+      return error(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class Error<T> implements UserState<T> {
+  const factory Error(final String message) = _$ErrorImpl<T>;
+
+  String get message;
+
+  /// Create a copy of UserState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$ErrorImplCopyWith<T, _$ErrorImpl<T>> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/interviewhatak/profile/data/model/user_model.dart
+++ b/lib/interviewhatak/profile/data/model/user_model.dart
@@ -1,0 +1,37 @@
+class UserModel {
+  final String name;
+  final String email;
+  final String phone;
+  final String? image;
+
+  UserModel({
+    required this.name,
+    required this.email,
+    required this.phone,
+    this.image =
+        'https://img.freepik.com/premium-vector/european-men-avatar_7814-344.jpg?w=740',
+  });
+
+  UserModel copyWith({
+    String? name,
+    String? email,
+    String? phone,
+    String? image,
+  }) {
+    return UserModel(
+      name: name ?? this.name,
+      email: email ?? this.email,
+      phone: phone ?? this.phone,
+      image: image ?? this.image,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      "name": this.name,
+      "email": this.email,
+      "phone": this.phone,
+      "image": this.image,
+    };
+  }
+}

--- a/lib/interviewhatak/profile/data/repository/user_repository.dart
+++ b/lib/interviewhatak/profile/data/repository/user_repository.dart
@@ -1,0 +1,21 @@
+import 'package:interviewhatak/core/networking/server_result.dart';
+import 'package:interviewhatak/core/networking/users/user_service.dart';
+import 'package:interviewhatak/interviewhatak/profile/data/model/user_model.dart';
+
+class UserRepository {
+  final UserService userService;
+
+  UserRepository(this.userService);
+
+  Future<ServerResult<UserModel>> getUser() async {
+    return await userService.getUser();
+  }
+
+  Future<ServerResult<void>> updateUser(UserModel user) async {
+    return await userService.updateUser(user);
+  }
+
+  Future<void> signOut() async {
+    return await userService.signOut();
+  }
+}

--- a/lib/interviewhatak/settings/controller/setting_cubit.dart
+++ b/lib/interviewhatak/settings/controller/setting_cubit.dart
@@ -1,0 +1,20 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:interviewhatak/core/helpers/shared_preference.dart';
+import 'package:interviewhatak/interviewhatak/settings/controller/setting_state.dart';
+
+class SettingCubit extends Cubit<SettingState> {
+  SettingCubit() : super(SettingState.initial());
+
+  bool isDark = false;
+
+  void changeMode(bool? value) {
+    if (value != null) {
+      isDark = value;
+    } else {
+      isDark = !isDark;
+    }
+    emit(SettingState.changed(isDark));
+
+    SharedPreference.setData('isDark', isDark);
+  }
+}

--- a/lib/interviewhatak/settings/controller/setting_state.dart
+++ b/lib/interviewhatak/settings/controller/setting_state.dart
@@ -1,0 +1,9 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+part 'setting_state.freezed.dart';
+
+@freezed
+class SettingState<T> with _$SettingState<T> {
+  const factory SettingState.initial() = _Initial;
+  const factory SettingState.changed(bool isDark) = Changed;
+  const factory SettingState.error({required String error}) = Error;
+}

--- a/lib/interviewhatak/settings/controller/setting_state.freezed.dart
+++ b/lib/interviewhatak/settings/controller/setting_state.freezed.dart
@@ -1,0 +1,487 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'setting_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$SettingState<T> {
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function(bool isDark) changed,
+    required TResult Function(String error) error,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initial,
+    TResult? Function(bool isDark)? changed,
+    TResult? Function(String error)? error,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function(bool isDark)? changed,
+    TResult Function(String error)? error,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initial<T> value) initial,
+    required TResult Function(Changed<T> value) changed,
+    required TResult Function(Error<T> value) error,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initial<T> value)? initial,
+    TResult? Function(Changed<T> value)? changed,
+    TResult? Function(Error<T> value)? error,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initial<T> value)? initial,
+    TResult Function(Changed<T> value)? changed,
+    TResult Function(Error<T> value)? error,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $SettingStateCopyWith<T, $Res> {
+  factory $SettingStateCopyWith(
+          SettingState<T> value, $Res Function(SettingState<T>) then) =
+      _$SettingStateCopyWithImpl<T, $Res, SettingState<T>>;
+}
+
+/// @nodoc
+class _$SettingStateCopyWithImpl<T, $Res, $Val extends SettingState<T>>
+    implements $SettingStateCopyWith<T, $Res> {
+  _$SettingStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of SettingState
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+abstract class _$$InitialImplCopyWith<T, $Res> {
+  factory _$$InitialImplCopyWith(
+          _$InitialImpl<T> value, $Res Function(_$InitialImpl<T>) then) =
+      __$$InitialImplCopyWithImpl<T, $Res>;
+}
+
+/// @nodoc
+class __$$InitialImplCopyWithImpl<T, $Res>
+    extends _$SettingStateCopyWithImpl<T, $Res, _$InitialImpl<T>>
+    implements _$$InitialImplCopyWith<T, $Res> {
+  __$$InitialImplCopyWithImpl(
+      _$InitialImpl<T> _value, $Res Function(_$InitialImpl<T>) _then)
+      : super(_value, _then);
+
+  /// Create a copy of SettingState
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+
+class _$InitialImpl<T> implements _Initial<T> {
+  const _$InitialImpl();
+
+  @override
+  String toString() {
+    return 'SettingState<$T>.initial()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$InitialImpl<T>);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function(bool isDark) changed,
+    required TResult Function(String error) error,
+  }) {
+    return initial();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initial,
+    TResult? Function(bool isDark)? changed,
+    TResult? Function(String error)? error,
+  }) {
+    return initial?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function(bool isDark)? changed,
+    TResult Function(String error)? error,
+    required TResult orElse(),
+  }) {
+    if (initial != null) {
+      return initial();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initial<T> value) initial,
+    required TResult Function(Changed<T> value) changed,
+    required TResult Function(Error<T> value) error,
+  }) {
+    return initial(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initial<T> value)? initial,
+    TResult? Function(Changed<T> value)? changed,
+    TResult? Function(Error<T> value)? error,
+  }) {
+    return initial?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initial<T> value)? initial,
+    TResult Function(Changed<T> value)? changed,
+    TResult Function(Error<T> value)? error,
+    required TResult orElse(),
+  }) {
+    if (initial != null) {
+      return initial(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _Initial<T> implements SettingState<T> {
+  const factory _Initial() = _$InitialImpl<T>;
+}
+
+/// @nodoc
+abstract class _$$ChangedImplCopyWith<T, $Res> {
+  factory _$$ChangedImplCopyWith(
+          _$ChangedImpl<T> value, $Res Function(_$ChangedImpl<T>) then) =
+      __$$ChangedImplCopyWithImpl<T, $Res>;
+  @useResult
+  $Res call({bool isDark});
+}
+
+/// @nodoc
+class __$$ChangedImplCopyWithImpl<T, $Res>
+    extends _$SettingStateCopyWithImpl<T, $Res, _$ChangedImpl<T>>
+    implements _$$ChangedImplCopyWith<T, $Res> {
+  __$$ChangedImplCopyWithImpl(
+      _$ChangedImpl<T> _value, $Res Function(_$ChangedImpl<T>) _then)
+      : super(_value, _then);
+
+  /// Create a copy of SettingState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? isDark = null,
+  }) {
+    return _then(_$ChangedImpl<T>(
+      null == isDark
+          ? _value.isDark
+          : isDark // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$ChangedImpl<T> implements Changed<T> {
+  const _$ChangedImpl(this.isDark);
+
+  @override
+  final bool isDark;
+
+  @override
+  String toString() {
+    return 'SettingState<$T>.changed(isDark: $isDark)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ChangedImpl<T> &&
+            (identical(other.isDark, isDark) || other.isDark == isDark));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, isDark);
+
+  /// Create a copy of SettingState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ChangedImplCopyWith<T, _$ChangedImpl<T>> get copyWith =>
+      __$$ChangedImplCopyWithImpl<T, _$ChangedImpl<T>>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function(bool isDark) changed,
+    required TResult Function(String error) error,
+  }) {
+    return changed(isDark);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initial,
+    TResult? Function(bool isDark)? changed,
+    TResult? Function(String error)? error,
+  }) {
+    return changed?.call(isDark);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function(bool isDark)? changed,
+    TResult Function(String error)? error,
+    required TResult orElse(),
+  }) {
+    if (changed != null) {
+      return changed(isDark);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initial<T> value) initial,
+    required TResult Function(Changed<T> value) changed,
+    required TResult Function(Error<T> value) error,
+  }) {
+    return changed(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initial<T> value)? initial,
+    TResult? Function(Changed<T> value)? changed,
+    TResult? Function(Error<T> value)? error,
+  }) {
+    return changed?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initial<T> value)? initial,
+    TResult Function(Changed<T> value)? changed,
+    TResult Function(Error<T> value)? error,
+    required TResult orElse(),
+  }) {
+    if (changed != null) {
+      return changed(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class Changed<T> implements SettingState<T> {
+  const factory Changed(final bool isDark) = _$ChangedImpl<T>;
+
+  bool get isDark;
+
+  /// Create a copy of SettingState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$ChangedImplCopyWith<T, _$ChangedImpl<T>> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$ErrorImplCopyWith<T, $Res> {
+  factory _$$ErrorImplCopyWith(
+          _$ErrorImpl<T> value, $Res Function(_$ErrorImpl<T>) then) =
+      __$$ErrorImplCopyWithImpl<T, $Res>;
+  @useResult
+  $Res call({String error});
+}
+
+/// @nodoc
+class __$$ErrorImplCopyWithImpl<T, $Res>
+    extends _$SettingStateCopyWithImpl<T, $Res, _$ErrorImpl<T>>
+    implements _$$ErrorImplCopyWith<T, $Res> {
+  __$$ErrorImplCopyWithImpl(
+      _$ErrorImpl<T> _value, $Res Function(_$ErrorImpl<T>) _then)
+      : super(_value, _then);
+
+  /// Create a copy of SettingState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? error = null,
+  }) {
+    return _then(_$ErrorImpl<T>(
+      error: null == error
+          ? _value.error
+          : error // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$ErrorImpl<T> implements Error<T> {
+  const _$ErrorImpl({required this.error});
+
+  @override
+  final String error;
+
+  @override
+  String toString() {
+    return 'SettingState<$T>.error(error: $error)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ErrorImpl<T> &&
+            (identical(other.error, error) || other.error == error));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, error);
+
+  /// Create a copy of SettingState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ErrorImplCopyWith<T, _$ErrorImpl<T>> get copyWith =>
+      __$$ErrorImplCopyWithImpl<T, _$ErrorImpl<T>>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function(bool isDark) changed,
+    required TResult Function(String error) error,
+  }) {
+    return error(this.error);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initial,
+    TResult? Function(bool isDark)? changed,
+    TResult? Function(String error)? error,
+  }) {
+    return error?.call(this.error);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function(bool isDark)? changed,
+    TResult Function(String error)? error,
+    required TResult orElse(),
+  }) {
+    if (error != null) {
+      return error(this.error);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initial<T> value) initial,
+    required TResult Function(Changed<T> value) changed,
+    required TResult Function(Error<T> value) error,
+  }) {
+    return error(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initial<T> value)? initial,
+    TResult? Function(Changed<T> value)? changed,
+    TResult? Function(Error<T> value)? error,
+  }) {
+    return error?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initial<T> value)? initial,
+    TResult Function(Changed<T> value)? changed,
+    TResult Function(Error<T> value)? error,
+    required TResult orElse(),
+  }) {
+    if (error != null) {
+      return error(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class Error<T> implements SettingState<T> {
+  const factory Error({required final String error}) = _$ErrorImpl<T>;
+
+  String get error;
+
+  /// Create a copy of SettingState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$ErrorImplCopyWith<T, _$ErrorImpl<T>> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/interviewhatak/settings/settings_screen.dart
+++ b/lib/interviewhatak/settings/settings_screen.dart
@@ -1,10 +1,49 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:icon_broken/icon_broken.dart';
+import 'package:interviewhatak/core/helpers/constants.dart';
+import 'package:interviewhatak/core/helpers/extensions.dart';
+import 'package:interviewhatak/core/theming/app_strings/app_string.dart';
+import 'package:interviewhatak/interviewhatak/profile/data/model/user_model.dart';
+import 'package:interviewhatak/interviewhatak/settings/controller/setting_cubit.dart';
+import 'package:interviewhatak/interviewhatak/settings/widgets/accounts_info.dart';
+import 'package:interviewhatak/interviewhatak/settings/widgets/additional_properties_info.dart';
+import 'package:interviewhatak/interviewhatak/settings/widgets/personal_image_stack.dart';
+import 'package:interviewhatak/interviewhatak/settings/widgets/user_email_and_user_name.dart';
 
 class SettingsScreen extends StatelessWidget {
-  const SettingsScreen({super.key});
+  final UserModel user;
+  const SettingsScreen({Key? key, required this.user}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    return Text('Settings Screen');
+    return Scaffold(
+      appBar: AppBar(
+        leading: IconButton(
+            onPressed: () {
+              context.pop();
+            },
+            icon: Icon(IconBroken.Arrow___Left)),
+        title: Text(AppString.settings),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 12),
+        child: Column(
+          spacing: 18.h,
+          children: [
+            Row(
+              spacing: 10.w,
+              children: [
+                PersonalImageStack(image: user.image ?? ''),
+                UserEmailAndUserName(name: user.name, email: user.email),
+              ],
+            ),
+            AccountsInfo(email: user.email, phone: user.phone),
+            AdditionalPropertiesInfo(),
+          ],
+        ),
+      ),
+    );
   }
 }

--- a/lib/interviewhatak/settings/widgets/accounts_info.dart
+++ b/lib/interviewhatak/settings/widgets/accounts_info.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:icon_broken/icon_broken.dart';
+import 'package:interviewhatak/core/helpers/separator.dart';
+import 'package:interviewhatak/core/theming/app_strings/app_string.dart';
+import 'package:interviewhatak/interviewhatak/settings/widgets/property_row_widget.dart';
+
+class AccountsInfo extends StatelessWidget {
+  final String email;
+  final String phone;
+  const AccountsInfo({super.key, required this.email, required this.phone});
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      elevation: 10,
+      borderRadius: BorderRadiusDirectional.circular(20),
+      child: Container(
+        width: double.infinity,
+        child: Padding(
+          padding: const EdgeInsets.all(8),
+          child: Column(
+            spacing: 12.h,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(AppString.account),
+              Row(
+                spacing: 5.w,
+                children: [
+                  Text(AppString.signedInAs),
+                  Text(email),
+                ],
+              ),
+              PropertyRowWidget(
+                  icon: IconBroken.Calling,
+                  hint: AppString.mobilePhone,
+                  title: phone),
+              heightSeparator(),
+              PropertyRowWidget(
+                icon: Icons.language_outlined,
+                hint: AppString.languages,
+                title: 'English',
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/interviewhatak/settings/widgets/additional_properties_info.dart
+++ b/lib/interviewhatak/settings/widgets/additional_properties_info.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:icon_broken/icon_broken.dart';
+import 'package:interviewhatak/core/helpers/separator.dart';
+import 'package:interviewhatak/core/theming/app_strings/app_string.dart';
+import 'package:interviewhatak/interviewhatak/settings/controller/setting_cubit.dart';
+import 'package:interviewhatak/interviewhatak/settings/controller/setting_state.dart';
+import 'package:interviewhatak/interviewhatak/settings/widgets/custom_switch.dart';
+import 'package:interviewhatak/interviewhatak/settings/widgets/property_row_widget.dart';
+
+class AdditionalPropertiesInfo extends StatelessWidget {
+  const AdditionalPropertiesInfo({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<SettingCubit, SettingState>(
+      builder: (context, state) {
+        return Material(
+          elevation: 10,
+          borderRadius: BorderRadiusDirectional.circular(20),
+          child: Container(
+            width: double.infinity,
+            child: Padding(
+              padding: const EdgeInsets.all(8),
+              child: Column(
+                spacing: 10.h,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(AppString.additional),
+                  Row(
+                    children: [
+                      PropertyRowWidget(
+                        icon: Icons.light_mode,
+                        hint: AppString.theme,
+                        title: context.read<SettingCubit>().isDark
+                            ? AppString.dark
+                            : AppString.light,
+                      ),
+                      Spacer(),
+                      CustomSwitch(
+                        initialValue: context.read<SettingCubit>().isDark,
+                        onChanged: (value) {
+                          context.read<SettingCubit>().changeMode(value);
+                        },
+                      ),
+                    ],
+                  ),
+                  heightSeparator(),
+                  PropertyRowWidget(
+                      icon: IconBroken.Notification,
+                      hint: AppString.notification,
+                      title: AppString.enabled),
+                  heightSeparator(),
+                  PropertyRowWidget(
+                      icon: IconBroken.Close_Square,
+                      hint: AppString.closeAccount,
+                      title: AppString.closeAccountFromGooglePlay),
+                ],
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/interviewhatak/settings/widgets/circular_avatar_icon_bg.dart
+++ b/lib/interviewhatak/settings/widgets/circular_avatar_icon_bg.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+import 'package:interviewhatak/core/theming/app_colors/app_colors.dart';
+
+class CircularAvatarIconBg extends StatelessWidget {
+  final IconData icon;
+  const CircularAvatarIconBg({super.key, required this.icon});
+
+  @override
+  Widget build(BuildContext context) {
+    return CircleAvatar(
+      radius: 25,
+      backgroundColor: AppColors.light,
+      child: Icon(icon),
+    );
+  }
+}

--- a/lib/interviewhatak/settings/widgets/custom_switch.dart
+++ b/lib/interviewhatak/settings/widgets/custom_switch.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import 'package:interviewhatak/core/theming/app_colors/app_colors.dart';
+
+class CustomSwitch extends StatelessWidget {
+  final bool initialValue;
+  final ValueChanged<bool> onChanged;
+
+  const CustomSwitch({
+    Key? key,
+    required this.initialValue,
+    required this.onChanged,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Switch(
+      value: initialValue,
+      onChanged: onChanged,
+      activeColor: AppColors.orange,
+    );
+  }
+}

--- a/lib/interviewhatak/settings/widgets/personal_image_stack.dart
+++ b/lib/interviewhatak/settings/widgets/personal_image_stack.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:icon_broken/icon_broken.dart';
+import 'package:interviewhatak/core/theming/app_colors/app_colors.dart';
+
+class PersonalImageStack extends StatelessWidget {
+  final String image;
+  const PersonalImageStack({super.key, required this.image});
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      alignment: AlignmentDirectional.bottomEnd,
+      children: [
+        CircleAvatar(
+          radius: 40,
+          backgroundColor: const Color(0xffD5C3AD),
+          child: CircleAvatar(
+            radius: 37,
+            backgroundImage: NetworkImage(image),
+          ),
+        ),
+        CircleAvatar(
+          radius: 15,
+          backgroundColor: AppColors.white,
+          child: IconButton(
+            onPressed: () {},
+            icon: Icon(
+              IconBroken.Edit,
+              size: 16.sp,
+              color: Colors.blue,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/interviewhatak/settings/widgets/property_row_widget.dart
+++ b/lib/interviewhatak/settings/widgets/property_row_widget.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:interviewhatak/interviewhatak/settings/widgets/circular_avatar_icon_bg.dart';
+
+class PropertyRowWidget extends StatelessWidget {
+  final IconData icon;
+  final String hint;
+  final String title;
+  const PropertyRowWidget(
+      {super.key, required this.icon, required this.hint, required this.title});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      spacing: 15.w,
+      children: [
+        CircularAvatarIconBg(icon: icon),
+        Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              hint,
+              style: Theme.of(context)
+                  .textTheme
+                  .bodyMedium
+                  ?.copyWith(fontSize: 13.sp, fontWeight: FontWeight.w500),
+            ),
+            Text(
+              title,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: Colors.grey,
+                    fontSize: 13.sp,
+                  ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/lib/interviewhatak/settings/widgets/user_email_and_user_name.dart
+++ b/lib/interviewhatak/settings/widgets/user_email_and_user_name.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:fluttertoast/fluttertoast.dart';
+import 'package:icon_broken/icon_broken.dart';
+import 'package:interviewhatak/core/theming/app_colors/app_colors.dart';
+
+class UserEmailAndUserName extends StatelessWidget {
+  final String name;
+  final String email;
+  const UserEmailAndUserName(
+      {super.key, required this.name, required this.email});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          name,
+          style: Theme.of(context)
+              .textTheme
+              .bodyMedium
+              ?.copyWith(fontWeight: FontWeight.w600),
+        ),
+        Row(
+          children: [
+            Text(email),
+            IconButton(
+              onPressed: () {
+                Clipboard.setData(
+                  ClipboardData(
+                    text: 'email',
+                  ),
+                ).then((value) {
+                  Fluttertoast.showToast(
+                    msg: 'copied',
+                    toastLength: Toast.LENGTH_SHORT,
+                    timeInSecForIosWeb: 3,
+                    backgroundColor: AppColors.brown,
+                  );
+                });
+              },
+              icon: const Icon(
+                IconBroken.Paper,
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/lib/interviewhatak_app.dart
+++ b/lib/interviewhatak_app.dart
@@ -1,29 +1,48 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:interviewhatak/core/helpers/constants.dart';
 import 'package:interviewhatak/core/routing/app_router.dart';
 import 'package:interviewhatak/core/routing/routes.dart';
 import 'package:interviewhatak/core/theming/app_strings/app_string.dart';
 import 'package:interviewhatak/core/theming/app_themes/theme_dark.dart';
 import 'package:interviewhatak/core/theming/app_themes/thme_light.dart';
+import 'package:interviewhatak/interviewhatak/settings/controller/setting_cubit.dart';
+import 'package:interviewhatak/interviewhatak/settings/controller/setting_state.dart';
 
 class InterviewhatakApp extends StatelessWidget {
   final AppRouter? appRouter;
+  final bool isDark;
 
-  const InterviewhatakApp({super.key, required this.appRouter});
+  const InterviewhatakApp(
+      {super.key, required this.appRouter, required this.isDark});
 
   @override
   Widget build(BuildContext context) {
     return ScreenUtilInit(
       designSize: Size(375, 812),
       minTextAdapt: true,
-      child: MaterialApp(
-        title: AppString.interviewhatak,
-        debugShowCheckedModeBanner: false,
-        initialRoute: Routes.dashboardScreen,
-        onGenerateRoute: appRouter?.generateRoute,
-        theme: themeLight,
-        darkTheme: themeDark,
-        themeMode: ThemeMode.system,
+      child: Builder(
+        builder: (context) {
+          return BlocProvider(
+            create: (context) => SettingCubit()..changeMode(Constants.isDark),
+            child: BlocBuilder<SettingCubit, SettingState>(
+              builder: (context, state) {
+                return MaterialApp(
+                  title: AppString.interviewhatak,
+                  debugShowCheckedModeBanner: false,
+                  initialRoute: Routes.splashScreen,
+                  onGenerateRoute: appRouter?.generateRoute,
+                  theme: context.read<SettingCubit>().isDark
+                      ? themeDark
+                      : themeLight,
+                  themeMode: ThemeMode.system,
+                );
+              },
+            ),
+          );
+        },
       ),
     );
   }

--- a/lib/main_development.dart
+++ b/lib/main_development.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:interviewhatak/core/di/dependency_injection.dart';
 import 'package:interviewhatak/core/helpers/app_constants.dart';
+import 'package:interviewhatak/core/helpers/constants.dart';
 import 'package:interviewhatak/core/helpers/extensions.dart';
 import 'package:interviewhatak/core/helpers/shared_preference.dart';
 import 'package:interviewhatak/core/routing/app_router.dart';
@@ -14,20 +15,23 @@ void main() async {
   await ScreenUtil.ensureScreenSize();
   setupGetIt();
   checkIfUserLoggedIn();
+  Constants.isDark = await SharedPreference.getBool('isDark');
   await Firebase.initializeApp(
     options: DefaultFirebaseOptions.currentPlatform,
   );
+
   runApp(
     InterviewhatakApp(
       appRouter: AppRouter(),
+      isDark: Constants.isDark,
     ),
   );
 }
 
 checkIfUserLoggedIn() async {
-  String userKey =
+  Constants.userKey =
       await SharedPreference.getString(SharedPreferenceKey.userUidKey);
-  if (!userKey.isNullOrEmpty()) {
+  if (!Constants.userKey.isNullOrEmpty()) {
     isLoggedUser = true;
   } else
     isLoggedUser = false;

--- a/lib/main_production.dart
+++ b/lib/main_production.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:interviewhatak/core/di/dependency_injection.dart';
 import 'package:interviewhatak/core/helpers/app_constants.dart';
+import 'package:interviewhatak/core/helpers/constants.dart';
 import 'package:interviewhatak/core/helpers/extensions.dart';
 import 'package:interviewhatak/core/helpers/shared_preference.dart';
 import 'package:interviewhatak/core/routing/app_router.dart';
@@ -17,9 +18,12 @@ void main() async {
   await Firebase.initializeApp(
     options: DefaultFirebaseOptions.currentPlatform,
   );
+  Constants.isDark = await SharedPreference.getBool('isDark');
+
   runApp(
     InterviewhatakApp(
       appRouter: AppRouter(),
+      isDark: Constants.isDark,
     ),
   );
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -453,6 +453,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  fluttertoast:
+    dependency: "direct main"
+    description:
+      name: fluttertoast
+      sha256: "24467dc20bbe49fd63e57d8e190798c4d22cbbdac30e54209d153a15273721d1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.2.10"
   freezed:
     dependency: "direct main"
     description:
@@ -797,6 +805,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
+  quickalert:
+    dependency: "direct main"
+    description:
+      name: quickalert
+      sha256: b5d62b1e20b08cc0ff5f40b6da519bdc7a5de6082f13d90572cf4e72eea56c5e
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   rxdart:
     dependency: transitive
     description:
@@ -1026,6 +1042,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      sha256: "9d06212b1362abc2f0f0d78e6f09f726608c74e3b9462e8368bb03314aa8d603"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.1"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      sha256: "6fc2f56536ee873eeb867ad176ae15f304ccccc357848b351f6f0d8d4a40d193"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.14"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      sha256: "16a513b6c12bb419304e72ea0ae2ab4fed569920d1c7cb850263fe3acc824626"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.2"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: "4e9ba368772369e3e08f231d2301b4ef72b9ff87c31192ef471b380ef29a4935"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.1"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      sha256: "17ba2000b847f334f16626a574c702b196723af2a289e7a93ffcb79acff855c2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: "3ba963161bd0fe395917ba881d320b9c4f6dd3c4a233da62ab18a5025c85f1e9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.0"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: "3284b6d2ac454cf34f114e1d3319866fdd1e19cdc329999057e44ffe936cfa77"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.4"
   uuid:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,6 +49,9 @@ dependencies:
   curved_navigation_bar: ^1.0.6
   # Flutter library to load and cache network images. Can also be used with placeholder and error widgets.
   cached_network_image: ^3.4.1
+  url_launcher: ^6.1.8
+  fluttertoast: ^8.2.10
+  quickalert: ^1.1.0
 
   lottie: ^3.3.0
 dev_dependencies:


### PR DESCRIPTION
- Isolate the screen into smaller widgets for better maintainability and reusability.
- Create a User Model, Service, Repository, and Cubit: 
-- Create a User model to hold user information.
-- Implement a user service to manage interactions (such as FirebaseFirestore calls and data fetching). 
-- Create a repository that connects the service layer to the UI. 
-- Implement a Cubit to handle updating and displaying the user’s information.
- Custom Switch Icon for Dark and Light Themes:
-- Create a custom switch widget that visually toggles between the dark and light themes.
- Toggle Between Two Themes Using Cubit: 
-- Use Cubit as the state management solution to toggle between dark and light themes. 
-- Store the theme state in SharedPreferences so the theme persists across app restarts.
-- Ensure the theme is immediately updated on the UI when the user toggles between dark and light mode.

![Screenshot_20250121-002026](https://github.com/user-attachments/assets/73aaac09-5d09-47a8-a9cf-1dce5460eda5)
![Screenshot_20250121-002017](https://github.com/user-attachments/assets/731cc17a-d91c-4fe8-a1d9-cd66dc1adcaa)

